### PR TITLE
docs(hublabbot): Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 #+STARTUP: showall
 * HubLabBot
 
-[[https://builtwithnix.org][https://builtwithnix.org/badge.svg]]
+[[https://builtwithnix.org][https://builtwithnix.org/badge.svg]] [[https://gitlab.com/Potpourri1/HubLabBot/-/commits/master][https://gitlab.com/Potpourri1/HubLabBot/badges/master/pipeline.svg]] [[https://hub.docker.com/r/potpourri/hublabbot][|Docker Hub|]] [[https://potpourri1.gitlab.io/HubLabBot/index.html][|Documentation|]]
 
 GitHub <-> GitLab integration supporter, interactive bot.
 
@@ -12,8 +12,8 @@ GitLab has a [[https://about.gitlab.com/solutions/github/][GitLab CI/CD for GitH
 - =gh_auto_merge_pr=
 Merge Pull Request if GitLab CI passed, no conflicts found,
 has required label and author in white list.\\
-Suboptions: =authors_white_list=, =delay= (default: =60= sec),
-=required_label= (default: =auto-merge=).
+Suboptions: =authors_white_list= (default: your login and your bot login),
+=delay= (default: =60= sec), =required_label_name= (default: =auto-merge=), ...
 
 - =gh_show_gitlab_ci_fail=
 Post comment with GitLab CI fail-report in PR's thread.\\
@@ -34,7 +34,11 @@ With [[./userscript/gitlab_delete_pipeline_button.user.js][userscript]] add dele
 ** Settings
 
 Settings stores in JSON file and environ variables. Path to settings file passes by first positional
-argument, default is =./hublabbot.json=.
+argument, default is =./hublabbot.json=. See more in [[https://potpourri1.gitlab.io/HubLabBot/settings.html#hublabbot.settings.HubLabBotSettings][HubLabBotSettings documentation]].
+
+** Releasing
+
+See [[./doc/RELEASING.org][RELEASING.org]].
 
 ** License
 

--- a/hublabbot/settings.py
+++ b/hublabbot/settings.py
@@ -14,7 +14,7 @@ from hublabbot.util import set_frozen_attr, JsonDict
 
 @dataclass(frozen=True)
 class GithubAutoMergeOption:
-	"""Immutable record to `gh_auto_merge_pr` option.
+	r"""Immutable record to `gh_auto_merge_pr` option.
 
 	Attributes:
 		authors_white_list: List of authors whose PR can be auto-merged. Your login and your bot's
@@ -23,7 +23,7 @@ class GithubAutoMergeOption:
 		required_label_name: Name of label required for PR to be auto-merged. Default is `'auto-merge'`.
 		required_label_color: Label color in hex format. Default is `'#852576'`.
 		required_label_description: Label description.
-			Default is `'HubLabBot's "gh_auto_merge_pr" required label'`.
+			Default is `'HubLabBot\'s "gh_auto_merge_pr" required label'`.
 
 	"""
 


### PR DESCRIPTION
- add GitLab CI badge for master
- add link to Docker Hub repo
- add link to documentation
- add Releasing section
- update description of `gh_auto_merge_pr` repo option
- fix docstring of class `GithubAutoMergeOption`