### PR TITLE
build(potpourri-bot): Fix Potpourri-bot Dockerfile

### DIFF
--- a/Potpourri-bot/Dockerfile
+++ b/Potpourri-bot/Dockerfile
@@ -4,4 +4,4 @@ COPY hublabbot.json /opt/hublabbot/
 
 # Pass Heroku http port to hublabbot
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["HUBLABBOT_PORT=$PORT exec hublabbot"]
+CMD HUBLABBOT_PORT=$PORT exec hublabbot


### PR DESCRIPTION
Heroku uses a non-standard way to run a container.