### PR TITLE
feat(hublabbot): Improve `gl_auto_cancel_pipelines` feature

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ Suboptions: =max_lines= (default: =25=).
 Enable GitLab CI for external Pull Requests.
 
 - =gl_auto_cancel_pipelines=
-Cancel all prevarious Pipelines with the same commit, if started new one.
+Cancel all prevarious Pipelines with the same branch, if started new one.
 
 - =gl_auto_delete_branches=
 Delete branch in GitLab when she deleted in GitHub.

--- a/hublabbot/settings.py
+++ b/hublabbot/settings.py
@@ -81,7 +81,7 @@ class RepoOptions:
 		gh_show_gitlab_ci_fail: `GithubShowGitlabCIFailOption`: Post comment with GitLab CI fail-report
 			in PR's thread. If `None`, it is disabled.
 		gh_gitlab_ci_for_external_pr: Enable GitLab CI for external Pull Requests.
-		gl_auto_cancel_pipelines: Cancel all prevarious Pipelines with the same commit,
+		gl_auto_cancel_pipelines: Cancel all prevarious Pipelines with the same branch,
 			if started new one.
 		gl_auto_delete_branches: Delete branch in GitLab when she deleted in GitHub.
 		gl_delete_pipeline_btn: With [userscript](https://github.com/Potpourri/HubLabBot/blob/master/userscript/gitlab_delete_pipeline_button.user.js)


### PR DESCRIPTION
- fix `gl_auto_cancel_pipelines` description (branch, not commit)
- now `gl_auto_cancel_pipelines` saves: latest pipeline per branch
  or latest pipeline triggered by pull request
- switch method GithubWebhook.get_pr_by_sha to public
- new method GithubWebhook.get_branch_head
- new method GitlabWebhook.cancel_pipeline
- refactoring code that uses GitLab API: do sort, filter on server side