### PR TITLE
ci(hublabbot): Speed up GitLab CI

### DIFF
--- a/tools/cfg/gitlab-ci.yaml
+++ b/tools/cfg/gitlab-ci.yaml
@@ -2,8 +2,7 @@ image: registry.gitlab.com/potpourri1/hublabbot
 
 stages:
   - commit-lint
-  - style-lint
-  - static-analysis
+  - code-lint
   - deploy-docs
 
 commit-lint:
@@ -14,14 +13,28 @@ commit-lint:
     - commit-lint
 
 style-lint:
-  stage: style-lint
+  stage: code-lint
   interruptible: true
   script: style-lint
+  rules:
+    - changes:
+      - hublabbot/**/*.py
+      - setup.{py,cfg}
+      - tools/style-lint
+      - tools/cfg/flake8-mypy.ini
+      - tools/cfg/cspell.json
 
 static-analysis:
-  stage: static-analysis
+  stage: code-lint
   interruptible: true
   script: static-analysis
+  rules:
+    - changes:
+      - hublabbot/**/*.py
+      - typeshed/**/*.pyi
+      - setup.{py,cfg}
+      - tools/static-analysis
+      - tools/cfg/jscpd.json
 
 pages:
   stage: deploy-docs
@@ -30,5 +43,9 @@ pages:
   artifacts:
     paths:
     - public
-  only:
-    - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      changes:
+      - hublabbot/**/*.py
+      - tools/build-docs
+      - tools/cfg/pdoc3/*


### PR DESCRIPTION
- replace stages 'style-lint' and 'static-analysis' with one 'code-lint'
- jobs 'style-lint' and 'static-analysis' are now in 'code-lint' stage
- jobs 'style-lint' and 'static-analysis' now run in parallel
- jobs 'style-lint', 'static-analysis', 'pages' now run only if used
  files have been changed
- replace `only` policies with `rules`